### PR TITLE
Simd wrapper

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,9 +2,12 @@ Copyright:
 
 Year(s)   Name                 Affiliation Email
 --------- -------------------- ----------- ---------------------------------
-2012-2014 Andreas Schäfer      FAU         gentryx@gmx.de
+2012-2015 Andreas Schäfer      FAU         gentryx@gmx.de
+2014-2015 Kurt Kanzenbach      FAU         kurt@kmk-computers.de
+2015-2015 Di Xiao (Larry)      SJTU        xiaodi@sjtu.edu.cn
 
 Affiliation Abbreviations:
 --------------------------
 
 FAU = Friedrich-Alexander-Universität Erlangen-Nürnberg
+SJTU = Shanghai Jiao Tong University

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
 
 # *0. Set the build target here
-set(INTEL_SSE TRUE)
+#set(INTEL_SSE TRUE)
 #set(ARM_NEON TRUE)
 #set(INTEL_AVX TRUE)
 #set(INTEL_AVX512 TRUE)
@@ -24,7 +24,7 @@ if (INTEL_AVX512)
     set(BOOST_LIBRARYDIR "/usr/lib64/")
     # test
     set(ADDITIONAL_COMPILE_FLAGS  "-D __AVX512__")
-endif (INTEL_AVX)
+endif(INTEL_AVX512)
 
 if (ARM_NEON)
     # Cross Compile

--- a/src/detail/short_vec_avx512_float_16.hpp
+++ b/src/detail/short_vec_avx512_float_16.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Andreas Schäfer
+ * Copyright 2015 Kurt Kanzenbach
  *
  * Distributed under the Boost Software License, Version 1.0. (See accompanying
  * file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/src/detail/short_vec_neon_float_4.hpp
+++ b/src/detail/short_vec_neon_float_4.hpp
@@ -3,7 +3,6 @@
 
 #ifdef __ARM_NEON__
 #include <arm_neon.h>
-#warning andi: NEON2
 
 #ifndef __CUDA_ARCH__
 

--- a/src/detail/short_vec_neon_float_4.hpp
+++ b/src/detail/short_vec_neon_float_4.hpp
@@ -1,8 +1,9 @@
 #ifndef FLAT_ARRAY_DETAIL_SHORT_VEC_NEON_FLOAT_4_HPP
 #define FLAT_ARRAY_DETAIL_SHORT_VEC_NEON_FLOAT_4_HPP
 
-#ifdef __NEON__
+#ifdef __ARM_NEON__
 #include <arm_neon.h>
+#warning andi: NEON2
 
 #ifndef __CUDA_ARCH__
 
@@ -93,7 +94,7 @@ public:
     inline
     short_vec<float, 4> sqrt() const
     {
-        // seems that vsqrtq_f32 is not yet implemented in the compiler 
+        // seems that vsqrtq_f32 is not yet implemented in the compiler
         //short_vec<float, 4> ret(vsqrtq_f32(val1));
         float32x4_t reciprocal = vrsqrteq_f32(val1);
         short_vec<float, 4> ret(vmulq_f32(val1, reciprocal));

--- a/src/detail/short_vec_scalar_float_4.hpp
+++ b/src/detail/short_vec_scalar_float_4.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Andreas Schäfer
+ * Copyright 2014-2015 Andreas Schäfer
  *
  * Distributed under the Boost Software License, Version 1.0. (See accompanying
  * file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,7 +9,7 @@
 #define FLAT_ARRAY_DETAIL_SHORT_VEC_SCALAR_FLOAT_4_HPP
 
 #ifndef __SSE__
-#ifndef __NEON__
+#ifndef __ARM_NEON__
 
 namespace LibFlatArray {
 

--- a/src/short_vec.hpp
+++ b/src/short_vec.hpp
@@ -48,6 +48,8 @@ public:
 
 #include <libflatarray/detail/short_vec_avx512_float_16.hpp>
 
+#include <libflatarray/detail/short_vec_neon_float_4.hpp>
+
 #include <libflatarray/detail/short_vec_scalar_double_1.hpp>
 #include <libflatarray/detail/short_vec_scalar_double_2.hpp>
 #include <libflatarray/detail/short_vec_scalar_double_4.hpp>

--- a/test/short_vec_test.cpp
+++ b/test/short_vec_test.cpp
@@ -130,8 +130,9 @@ void testImplementation()
         &vec2[i] << (v / w);
     }
     for (int i = 0; i < numElements; ++i) {
-        // accept lower accuracy for estimated division:
-        TEST_REAL_ACCURACY((i + 0.1) / (i + 0.2), vec2[i], 0.0002);
+        // accept lower accuracy for estimated division, really low
+        // accuracy accepted because of results from ARM NEON:
+        TEST_REAL_ACCURACY((i + 0.1) / (i + 0.2), vec2[i], 0.0025);
     }
 
     // test /=
@@ -145,8 +146,9 @@ void testImplementation()
         &vec2[i] << v;
     }
     for (int i = 0; i < numElements; ++i) {
-        // here, too, lower accuracy is acceptable.
-        TEST_REAL_ACCURACY((i + 0.1) / (i + 0.2), vec2[i], 0.0002);
+        // here, too, lower accuracy is acceptable. As with divisions,
+        // ARM NEON costs us an order of magnitude here compared to X86.
+        TEST_REAL_ACCURACY((i + 0.1) / (i + 0.2), vec2[i], 0.0025);
     }
 
     // test sqrt()
@@ -155,7 +157,8 @@ void testImplementation()
         &vec2[i] << sqrt(v);
     }
     for (int i = 0; i < numElements; ++i) {
-        TEST_REAL(std::sqrt(double(i + 0.1)), vec2[i]);
+        // lower accuracy, mainly for ARM NEON
+        TEST_REAL_ACCURACY(std::sqrt(double(i + 0.1)), vec2[i], 0.002);
     }
 
     // test "/ sqrt()"
@@ -170,7 +173,7 @@ void testImplementation()
     for (int i = 0; i < numElements; ++i) {
         // the expression "foo / sqrt(bar)" will again result in an
         // estimated result for single precision floats, so lower accuracy is acceptable:
-        TEST_REAL_ACCURACY((i + 0.2) / std::sqrt(double(i + 0.1)), vec2[i], 0.0003);
+        TEST_REAL_ACCURACY((i + 0.2) / std::sqrt(double(i + 0.1)), vec2[i], 0.003);
     }
 
     // test string conversion
@@ -272,7 +275,7 @@ ADD_TEST(TestImplementationStrategyFloat)
 
 #ifdef __SSE__
 #define EXPECTED_TYPE short_vec_strategy::sse
-#elif __NEON__
+#elif __ARM_NEON__
 #define EXPECTED_TYPE short_vec_strategy::neon
 #else
 #define EXPECTED_TYPE short_vec_strategy::scalar


### PR DESCRIPTION
Works for me on the Jetson boards. Quick listing for testing:

```
gentryx@faui36b ~ $ srun --gres=jetson:1 --pty bash
gentryx@faui36c ~ $ ssh_jetson
trying /var/spool/alloc/jetson_0...
  DEVICE_ID: 0
  SOCKET_FILE: /var/tmp/jetson0.sock
  PORT: 2000
  PORT: 2000
Welcome to Ubuntu 14.04.2 LTS (GNU/Linux 3.10.40-ged4f697 armv7l)

 * Documentation:  https://help.ubuntu.com/

116 packages can be updated.
69 updates are security updates.

Last login: Tue Jun 30 01:25:45 2015 from 10.1.1.1
gentryx@tegra-ubuntu01:~$ cd floppy/libflatarray_larry/
gentryx@tegra-ubuntu01:~/floppy/libflatarray_larry$ mkdir bld
gentryx@tegra-ubuntu01:~/floppy/libflatarray_larry$ cd bld
gentryx@tegra-ubuntu01:~/floppy/libflatarray_larry/bld$ cmake -DADDITIONAL_COMPILE_FLAGS="-mfpu=neon" ../
-- The C compiler identification is GNU 4.8.2
-- The CXX compiler identification is GNU 4.8.2
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Boost version: 1.54.0
-- Found the following Boost libraries:
--   date_time
--   filesystem
--   system
-- Found CUDA: /usr/local/cuda-6.5 (found version "6.5") 
-- Performing Test SUPPORTS_MARCH_NATIVE
-- Performing Test SUPPORTS_MARCH_NATIVE - Success
-- The following options have been configured:


 * ADDITIONAL_COMPILE_FLAGS="-mfpu=neon",
   default=" -march=native"
   Add these flags when compiling.

 * WITH_CUDA="TRUE",
   default="TRUE"
   Enable modules which harness Nvidia CUDA GPUs

 * LIB_INSTALL_DIR="lib",
   default="lib"
   Directory where libraries will be installed to, may be overridden for 64-bit installations

-- Configuring done
-- Generating done
-- Build files have been written to: /home/gentryx/floppy/libflatarray_larry/bld
gentryx@tegra-ubuntu01:~/floppy/libflatarray_larry/bld$ make -j5
[  5%] Scanning dependencies of target soa_array_test
Scanning dependencies of target short_vec_test
Building NVCC (Device) object test/CMakeFiles/cuda_allocator_test.dir//./cuda_allocator_test_generated_cuda_allocator_test.cu.o
[ 10%] Scanning dependencies of target aligned_allocator_test
[ 15%] Scanning dependencies of target api_traits_test
[ 21%] Building CXX object test/CMakeFiles/soa_array_test.dir/soa_array_test.cpp.o
[ 26%] Building CXX object test/CMakeFiles/short_vec_test.dir/short_vec_test.cpp.o
Building CXX object test/CMakeFiles/aligned_allocator_test.dir/aligned_allocator_test.cpp.o
Building CXX object test/CMakeFiles/api_traits_test.dir/api_traits_test.cpp.o
Linking CXX executable aligned_allocator_test
[ 26%] Built target aligned_allocator_test
Scanning dependencies of target soa_grid_test
[ 31%] Linking CXX executable soa_array_test
Building CXX object test/CMakeFiles/soa_grid_test.dir/soa_grid_test.cpp.o
[ 31%] Built target soa_array_test
Scanning dependencies of target charged_particles
[ 36%] Building CXX object examples/charged_particles/CMakeFiles/charged_particles.dir/main.cpp.o
Linking CXX executable charged_particles
[ 36%] Built target charged_particles
Scanning dependencies of target cuda_allocator_test
Scanning dependencies of target jacobi
[ 42%] Linking CXX executable api_traits_test
Linking CXX executable cuda_allocator_test
Building CXX object examples/jacobi/CMakeFiles/jacobi.dir/main.cpp.o
Linking CXX executable soa_grid_test
[ 47%] [ 47%] Linking CXX executable jacobi
[ 47%] Built target cuda_allocator_test
Built target api_traits_test
[ 47%] Built target soa_grid_test
Building CXX object test/CMakeFiles/short_vec_test.dir/short_vec_additional_test.cpp.o
[ 52%] [ 52%] Built target jacobi
[ 57%] [ 63%] Building NVCC (Device) object examples/lbm/CMakeFiles/lbm2.dir//./lbm2_generated_flatarray_implementation_8.cu.o
[ 68%] Building NVCC (Device) object examples/lbm/CMakeFiles/lbm2.dir//./lbm2_generated_flatarray_implementation_0.cu.o
Linking CXX executable short_vec_test
Building NVCC (Device) object examples/lbm/CMakeFiles/lbm2.dir//./lbm2_generated_flatarray_implementation_1.cu.o
Building NVCC (Device) object examples/lbm/CMakeFiles/lbm2.dir//./lbm2_generated_main.cu.o
[ 68%] Built target short_vec_test
[ 73%] Building NVCC (Device) object examples/lbm/CMakeFiles/lbm2.dir//./lbm2_generated_flatarray_implementation_2.cu.o

[ 78%] Building NVCC (Device) object examples/lbm/CMakeFiles/lbm2.dir//./lbm2_generated_flatarray_implementation_3.cu.o
[ 84%] Building NVCC (Device) object examples/lbm/CMakeFiles/lbm2.dir//./lbm2_generated_flatarray_implementation_4.cu.o
[ 89%] Building NVCC (Device) object examples/lbm/CMakeFiles/lbm2.dir//./lbm2_generated_flatarray_implementation_5.cu.o
[ 94%] [100%] Building NVCC (Device) object examples/lbm/CMakeFiles/lbm2.dir//./lbm2_generated_flatarray_implementation_7.cu.o
Building NVCC (Device) object examples/lbm/CMakeFiles/lbm2.dir//./lbm2_generated_flatarray_implementation_6.cu.o

Scanning dependencies of target lbm2
Linking CXX executable lbm2
[100%] Built target lbm2
gentryx@tegra-ubuntu01:~/floppy/libflatarray_larry/bld$ make -j4 check
-- Boost version: 1.54.0
-- Found the following Boost libraries:
--   date_time
--   filesystem
--   system
-- The following options have been configured:


 * ADDITIONAL_COMPILE_FLAGS="-mfpu=neon",
   default=" -march=native"
   Add these flags when compiling.

 * WITH_CUDA="TRUE",
   default="TRUE"
   Enable modules which harness Nvidia CUDA GPUs

 * LIB_INSTALL_DIR="lib",
   default="lib"
   Directory where libraries will be installed to, may be overridden for 64-bit installations

-- Configuring done
-- Generating done
-- Build files have been written to: /home/gentryx/floppy/libflatarray_larry/bld
[ 14%] Built target soa_grid_test
[ 42%] Built target short_vec_test
[ 57%] Built target soa_array_test
Linking CXX executable cuda_allocator_test
[ 71%] Built target api_traits_test
Scanning dependencies of target run_short_vec_test
Scanning dependencies of target run_soa_grid_test
[ 85%] running short_vec_test
[100%] running soa_grid_test
Built target cuda_allocator_test
Built target aligned_allocator_test
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
[100%] Built target run_soa_grid_test
[100%] Built target run_short_vec_test
Scanning dependencies of target run_api_traits_test
Scanning dependencies of target run_aligned_allocator_test
Scanning dependencies of target run_soa_array_test
running api_traits_test
Scanning dependencies of target run_cuda_allocator_test
running aligned_allocator_test
running soa_array_test
Passed
64, 32, 1
Passed
Passed
Passed
Passed
Passed
Passed
Passed
Passed
running cuda_allocator_test
Passed
Passed
Passed
Passed
[100%] Built target run_soa_array_test
[100%] Built target run_aligned_allocator_test
[100%] [100%] Built target run_api_traits_test
Built target run_cuda_allocator_test
Scanning dependencies of target check
Tests passed.
[100%] Built target check
```
